### PR TITLE
Turn .gitignore into a {white,allow}list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,25 @@
+# Disallow everything
+
+*
+
+# Allow specific files
+
+!.gitignore
+!LICENSE
+
+# Allow file types (in subfolders) with a !
+
+!**/
+!*.m
+!*.mlapp
+!*.md
+!*.png
+!*.fig
+!*.txt
+!README
+
+# These are apparently not a part of the app itself, so keep ignoring them
+
 profile
 data
 cluster


### PR DESCRIPTION
This commit turns the `.gitignore` file into an allowlist, which prevents the
addition of any unwanted file types by default, and explicitly declares which
file types are allowed. This should prevent any future additions of files like
`.DS_Store` or Matlab's backup format `.asv`. The latter is not needed, because
you know, WE ARE USING VERSION CONTROL.

If a needed file type is missing from the new Allow file types -section of the
.gitignore file, please comment on the pull/merge request related to this
commit and it will be amended.

NOTE: Pushes may still be forced with the -f switch after this change. DO NOT
DO THIS. You are a dingus if you do.