### PR TITLE
Renamed m/{volume_gradient → zef_volume_gradient}.m

### DIFF
--- a/m/compute_eit_data.m
+++ b/m/compute_eit_data.m
@@ -147,7 +147,7 @@ waitbar_ind = 0;
 D_A_count = 0;
 for i = 1 : 4
 
-grad_1 = volume_gradient(nodes, tetrahedra, i);
+grad_1 = zef_volume_gradient(nodes, tetrahedra, i);
 
 for j = i : 4
 
@@ -156,7 +156,7 @@ D_A_count = D_A_count + 1;
 if i == j
 grad_2 = grad_1;
 else
-grad_2 = volume_gradient(nodes, tetrahedra, i);
+grad_2 = zef_volume_gradient(nodes, tetrahedra, i);
 end
 
 entry_vec = zeros(1,size(tetrahedra,1));

--- a/m/forward_scripts/brain/lead_field_eeg_fem.m
+++ b/m/forward_scripts/brain/lead_field_eeg_fem.m
@@ -204,14 +204,14 @@ waitbar_ind = 0;
 
 for i = 1 : 4
 
-    grad_1 = volume_gradient(nodes, tetrahedra, i);
+    grad_1 = zef_volume_gradient(nodes, tetrahedra, i);
 
     for j = i : 4
 
         if i == j
             grad_2 = grad_1;
         else
-            grad_2 = volume_gradient(nodes, tetrahedra, j);
+            grad_2 = zef_volume_gradient(nodes, tetrahedra, j);
         end
 
         entry_vec = zeros(1,size(tetrahedra,1));

--- a/m/forward_scripts/brain/lead_field_eit_fem.m
+++ b/m/forward_scripts/brain/lead_field_eit_fem.m
@@ -132,7 +132,7 @@ waitbar_ind = 0;
 D_A_count = 0;
 for i = 1 : 4
 
-grad_1 = volume_gradient(nodes, tetrahedra, i);
+grad_1 = zef_volume_gradient(nodes, tetrahedra, i);
 
 for j = i : 4
 
@@ -141,7 +141,7 @@ D_A_count = D_A_count + 1;
 if i == j
 grad_2 = grad_1;
 else
-grad_2 = volume_gradient(nodes, tetrahedra, j);
+grad_2 = zef_volume_gradient(nodes, tetrahedra, j);
 end
 
 entry_vec = zeros(1,size(tetrahedra,1));

--- a/m/forward_scripts/brain/lead_field_meg_fem.m
+++ b/m/forward_scripts/brain/lead_field_meg_fem.m
@@ -124,7 +124,7 @@ tic;
 load_vec_count = 0;
 for i = 1 : 4
 
-grad_1 = volume_gradient(nodes, tetrahedra, i);
+grad_1 = zef_volume_gradient(nodes, tetrahedra, i);
 
 for j = 1 : L
 
@@ -160,14 +160,14 @@ waitbar(0,h,'System matrices.')
 
 for i = 1 : 4
 
-grad_1 = volume_gradient(nodes, tetrahedra, i);
+grad_1 = zef_volume_gradient(nodes, tetrahedra, i);
 
 for j = i : 4
 
 if i == j
 grad_2 = grad_1;
 else
-grad_2 = volume_gradient(nodes, tetrahedra, j);
+grad_2 = zef_volume_gradient(nodes, tetrahedra, j);
 end
 
 entry_vec = zeros(1,size(tetrahedra,1));

--- a/m/forward_scripts/brain/lead_field_meg_grad_fem.m
+++ b/m/forward_scripts/brain/lead_field_meg_grad_fem.m
@@ -126,7 +126,7 @@ tic;
 load_vec_count = 0;
 for i = 1 : 4
 
-grad_1 = volume_gradient(nodes, tetrahedra, i);
+grad_1 = zef_volume_gradient(nodes, tetrahedra, i);
 
 for j = 1 : L
 
@@ -165,14 +165,14 @@ waitbar(0,h,'System matrices.')
 
 for i = 1 : 4
 
-grad_1 = volume_gradient(nodes, tetrahedra, i);
+grad_1 = zef_volume_gradient(nodes, tetrahedra, i);
 
 for j = i : 4
 
 if i == j
 grad_2 = grad_1;
 else
-grad_2 = volume_gradient(nodes, tetrahedra, j);
+grad_2 = zef_volume_gradient(nodes, tetrahedra, j);
 end
 
 entry_vec = zeros(1,size(tetrahedra,1));

--- a/m/forward_scripts/brain/lead_field_tes_fem.m
+++ b/m/forward_scripts/brain/lead_field_tes_fem.m
@@ -193,12 +193,12 @@ h = waitbar(0,'System matrices.');
 waitbar_ind = 0;
 
 for i = 1 : 4
-    grad_1 = volume_gradient(nodes, tetrahedra, i);
+    grad_1 = zef_volume_gradient(nodes, tetrahedra, i);
     for j = i : 4
         if i == j
             grad_2 = grad_1;
         else
-            grad_2 = volume_gradient(nodes, tetrahedra, j);
+            grad_2 = zef_volume_gradient(nodes, tetrahedra, j);
         end
         entry_vec = zeros(1,size(tetrahedra,1));
         for k = 1 : 6

--- a/m/zef_volume_gradient.m
+++ b/m/zef_volume_gradient.m
@@ -1,4 +1,4 @@
-function gradients = volume_gradient(nodes, tetrahedra, node_index)
+function gradients = zef_volume_gradient(nodes, tetrahedra, node_index)
 % Calculates all of the ∇𝑉 of tetrahedra in the generated finite element mesh
 % as a triple product a ⋅ (b × c). See https://math.stackexchange.com/q/797845
 % for the general idea.


### PR DESCRIPTION
This was simply to reduce the chance of the function name clashing with
functions of similar names from other packages.