### PR TITLE
Renamed m/{volume → zef_tetra_volume}.m

### DIFF
--- a/m/compute_eit_data.m
+++ b/m/compute_eit_data.m
@@ -124,7 +124,7 @@ if iscell(elements)
     A = spalloc(N,N,0);
     D_A = zeros(K,10);
 
-tilavuus = volume(nodes, tetrahedra);
+tilavuus = zef_tetra_volume(nodes, tetrahedra);
 
 roi_ind_vec = [];
 

--- a/m/forward_scripts/brain/lead_field_eeg_fem.m
+++ b/m/forward_scripts/brain/lead_field_eeg_fem.m
@@ -197,7 +197,7 @@ Aux_mat = [
     - ...
     repmat(nodes(tetrahedra(:,4),:)',3,1);
 
-tilavuus = volume(nodes, tetrahedra);
+tilavuus = zef_tetra_volume(nodes, tetrahedra);
 
 h=waitbar(0,'System matrices.');
 waitbar_ind = 0;

--- a/m/forward_scripts/brain/lead_field_eit_fem.m
+++ b/m/forward_scripts/brain/lead_field_eit_fem.m
@@ -124,7 +124,7 @@ if iscell(elements)
     A = spalloc(N,N,0);
     D_A = zeros(K,10);
 
-tilavuus = volume(nodes, tetrahedra);
+tilavuus = zef_tetra_volume(nodes, tetrahedra);
 
 h=waitbar(0,'System matrices.');
 waitbar_ind = 0;

--- a/m/forward_scripts/brain/lead_field_meg_fem.m
+++ b/m/forward_scripts/brain/lead_field_meg_fem.m
@@ -112,7 +112,7 @@ end
 
 A = spalloc(N,N,0);
 
-tilavuus = volume(nodes, tetrahedra);
+tilavuus = zef_tetra_volume(nodes, tetrahedra);
 
 h=waitbar(0,'MEG load vectors.');
 waitbar_ind = 0;

--- a/m/forward_scripts/brain/lead_field_meg_grad_fem.m
+++ b/m/forward_scripts/brain/lead_field_meg_grad_fem.m
@@ -114,7 +114,7 @@ end
 
 A = spalloc(N,N,0);
 
-tilavuus = volume(nodes, tetrahedra);
+tilavuus = zef_tetra_volume(nodes, tetrahedra);
 
 h=waitbar(0,'MEG load vectors.');
 waitbar_ind = 0;

--- a/m/forward_scripts/brain/lead_field_tes_fem.m
+++ b/m/forward_scripts/brain/lead_field_tes_fem.m
@@ -185,7 +185,7 @@ clear electrodes;
 % A
 A = spalloc(N,N,0);
 
-tilavuus = volume(nodes, tetrahedra);
+tilavuus = zef_tetra_volume(nodes, tetrahedra);
 
 clear Aux_mat;
 

--- a/m/forward_scripts/gravity/compute_gravity_data.m
+++ b/m/forward_scripts/gravity/compute_gravity_data.m
@@ -110,7 +110,7 @@ if iscell(elements)
     A = spalloc(N,N,0);
     D_A = zeros(K,10);
 
-tilavuus = volume(nodes, tetrahedra);
+tilavuus = zef_tetra_volume(nodes, tetrahedra);
 
 roi_ind_vec = [];
 

--- a/m/forward_scripts/gravity/lead_field_gravity.m
+++ b/m/forward_scripts/gravity/lead_field_gravity.m
@@ -135,7 +135,7 @@ if iscell(elements)
 
 
 
-tilavuus = volume(nodes, tetrahedra);
+tilavuus = zef_tetra_volume(nodes, tetrahedra);
 
 c_tet = 0.25*(nodes(tetrahedra(:,1),:) + nodes(tetrahedra(:,2),:) + nodes(tetrahedra(:,3),:) + nodes(tetrahedra(:,4),:));
 

--- a/m/forward_scripts/gravity/lead_field_gravity_grad.m
+++ b/m/forward_scripts/gravity/lead_field_gravity_grad.m
@@ -134,7 +134,7 @@ if iscell(elements)
 
 
 
-tilavuus = volume(nodes, tetrahedra);
+tilavuus = zef_tetra_volume(nodes, tetrahedra);
 
 c_tet = 0.25*(nodes(tetrahedra(:,1),:) + nodes(tetrahedra(:,2),:) + nodes(tetrahedra(:,3),:) + nodes(tetrahedra(:,4),:));
 

--- a/m/zef_mesh_refinement.m
+++ b/m/zef_mesh_refinement.m
@@ -267,7 +267,7 @@ tetra_interp_vec = [tetra_interp_vec; tetra_interp_vec_new];
 
 clear tetra_new_ind tetra_new_out;
 
-tilavuus = volume(nodes, tetra);
+tilavuus = zef_tetra_volume(nodes, tetra);
 
 I = find(tilavuus > 0);
 tetra(I,:) = tetra(I,[2 1 3 4]);

--- a/m/zef_refinement_step.m
+++ b/m/zef_refinement_step.m
@@ -275,7 +275,7 @@ clear tetra_new_ind tetra_new_out;
 
 waitbar(10/length_waitbar,h,'Surface refinement.');
 
-tilavuus = volume(nodes, tetrahedra);
+tilavuus = zef_tetra_volume(nodes, tetrahedra);
 
 I = find(tilavuus > 0);
 tetra(I,:) = tetra(I,[2 1 3 4]);

--- a/m/zef_tetra_volume.m
+++ b/m/zef_tetra_volume.m
@@ -1,4 +1,4 @@
-function V = volume(nodes, tetrahedra)
+function V = zef_tetra_volume(nodes, tetrahedra)
 % TILAVUUS - Calculates a volume V from a given set of finite element nodes,
 % the corresponding tetrahedra and suitable index matrix.
 %


### PR DESCRIPTION
Again, just like with commit c25289c59d555367a91bbec5827b707761e3efb3, the
purpose of this commit is to reduce the chance of the tetrahedron volume
function clashing with external ones.

Also again, file formats were changed from dos → unix, so a few files will
look like they've been replaced entirely, but in reality only the function
invocation as altered to match the new name.