### PR TITLE
Calls to volume → zef_tetra_volume in plugins/

### DIFF
--- a/plugins/DynamicalPlotQueue/m/dynamical_plot_queue_bank/zef_dpq_plot_resection.m
+++ b/plugins/DynamicalPlotQueue/m/dynamical_plot_queue_bank/zef_dpq_plot_resection.m
@@ -19,7 +19,7 @@ D = delaunayTriangulation(resection_points(:,1),resection_points(:,2),resection_
 nodes = D.Points;
 tetrahedra = D.ConnectivityList;
 
-tilavuus = volume(nodes, tetrahedra);
+tilavuus = zef_tetra_volume(nodes, tetrahedra);
 
 c_points = 0.25*(nodes(tetrahedra(:,1),:)+ nodes(tetrahedra(:,2),:)+nodes(tetrahedra(:,3),:)+nodes(tetrahedra(:,4),:));
 

--- a/plugins/EITSensitivityTool/m/zef_eit_sensitivity_tool_volume.m
+++ b/plugins/EITSensitivityTool/m/zef_eit_sensitivity_tool_volume.m
@@ -3,6 +3,6 @@ function tilavuus_vec = zef_eit_sensitivity_tool_volume
 nodes = evalin('base','zef.nodes');
 tetrahedra = evalin('base','zef.tetra');
 
-tilavuus = volume(nodes, tetrahedra);
+tilavuus = zef_tetra_volume(nodes, tetrahedra);
 tilavuus = tilavuus(:);
 tilavuus_vec = accumarray(evalin('base','zef.eit_ind'),tilavuus(evalin('base','zef.brain_ind')),[size(evalin('base','zef.eit_count'),1) 1]);

--- a/plugins/FindSyntheticGravityData/m/compute_gravity_data.m
+++ b/plugins/FindSyntheticGravityData/m/compute_gravity_data.m
@@ -109,7 +109,7 @@ if iscell(elements)
     A = spalloc(N,N,0);
     D_A = zeros(K,10);
 
-tilavuus = volume(nodes, tetrahedra);
+tilavuus = zef_tetra_volume(nodes, tetrahedra);
 
 roi_ind_vec = [];
 

--- a/plugins/WireframeTool/m/wireframe.m
+++ b/plugins/WireframeTool/m/wireframe.m
@@ -63,7 +63,7 @@ end
 n_nodes = size(nodes,1);
 n_tetra = size(tetra,1);
 
-tilavuus = volume(nodes, tetra);
+tilavuus = zef_tetra_volume(nodes, tetra);
 
 p_triangles = [
      4     2     1


### PR DESCRIPTION
The function renaming `m/{volume → zef_tetra_volume}` took place in
commit ae71bfe. This brings the plugins-folder up-to-date with the change.