### PR TITLE
Added a missing semicolon to tetra volume calculation

### DIFF
--- a/m/zef_tetra_volume.m
+++ b/m/zef_tetra_volume.m
@@ -58,6 +58,6 @@ function V = zef_tetra_volume(nodes, tetrahedra, take_absolute_value)
     );
 
     if take_absolute_value
-        V = abs(V)
+        V = abs(V);
     end
 end


### PR DESCRIPTION
Now the volume absolute values should no longer be printed on screen.