### PR TITLE
Add waitbars to functions zef_build_electrodes and zef_stiffness_matrix

### DIFF
--- a/m/forward_scripts/brain/lead_field_eeg_fem.m
+++ b/m/forward_scripts/brain/lead_field_eeg_fem.m
@@ -157,11 +157,6 @@ if iscell(elements)
 source_model = 1;
 end
 
-% Initialize wait bar
-
-h=waitbar(0,'System matrices.');
-waitbar_ind = 0;
-
 % Volume
 
 tilavuus = zef_tetra_volume(nodes, tetrahedra, true);
@@ -175,6 +170,11 @@ clear tilavuus ala sigma_tetrahedra;
 % Build electrode matrices B and C based on A
 
 [A, B, C] = zef_build_electrodes(nodes, electrode_model, impedance_vec, impedance_inf, ele_ind, A, N, L);
+
+% Titles for waitbar
+
+fititle = 'Face-intersecting G and L';
+ewtitle = 'Edgewise G and L';
 
 % Transfer matrix with preconditioned conjugate gradient (PCG) iteration
 
@@ -196,6 +196,11 @@ clear A_aux A_part;
 %Form G_fi and T_fi
 %*******************************
 %*******************************
+
+% Initialize wait bar
+
+h=waitbar(0,fititle);
+waitbar_ind = 0;
 
 %An auxiliary matrix for picking up the correct nodes from tetrahedra
 ind_m = [ 2 3 4 ;
@@ -257,7 +262,12 @@ T_fi = sparse(repmat([1:M_fi]',2,1),[Ind_mat(:,1);Ind_mat(:,2)],ones(2*M_fi,1), 
 
 clear I tetrahedra_aux_ind_1 tetrahedra_aux_ind_2;
 
+waitbar(1, h);
+
 %Form G_ew and T_ew
+
+waitbar(0,h,ewtitle);
+
 if source_model == 2
 %*******************************
 %*******************************
@@ -290,6 +300,8 @@ G_ew = sparse([edge_ind(:,1)  ; edge_ind(:,2)],repmat([1:M_ew]',2,1),[1./(ew_sou
 
 T_ew = sparse(edge_ind_aux_2, Ind_mat(:,1), ones(length(edge_ind_aux_2),1), M_ew, K2);
 clear I tetrahedra_aux_ind_1 tetrahedra_aux_ind_2;
+
+waitbar(1,h);
 
 %*******************************
 %*******************************

--- a/m/forward_scripts/brain/lead_field_tes_fem.m
+++ b/m/forward_scripts/brain/lead_field_tes_fem.m
@@ -182,11 +182,6 @@ K = length(brain_ind);
 
 clear electrodes;
 
-% Initialize progress bar
-
-h = waitbar(0,'System matrices.');
-waitbar_ind = 0;
-
 % Get the total volume tilavuus of the domain Ω.
 
 tilavuus = zef_tetra_volume(nodes, tetrahedra, true);
@@ -238,6 +233,11 @@ A = zef_stiffness_matrix(nodes, tetrahedra, tilavuus, sigma_tetrahedra);
 ,                                          ...
     m_max                                  ...
 );
+
+% Initialize progress bar
+
+h = waitbar(0,'Form L_tes from transfer matrix R_tes.');
+waitbar_ind = 0;
 
 % Modify transfer matrix R_tes for lead field L_tes calculation
 

--- a/m/operators/zef_stiffness_matrix.m
+++ b/m/operators/zef_stiffness_matrix.m
@@ -13,19 +13,26 @@ function A = zef_stiffness_matrix(nodes, tetrahedra, volume, tensor)
 % holds with 𝑢 being the non-discretized scalar function 𝑢 on the boundary ∂Ω
 % of the domain and 𝑛⃗ is an outward-pointing surface normal on ∂Ω.
 
+    % Wait bar and its progress index
+
+    wb = waitbar(0,'Stiffness matrix.');
+    wbi = 0;
+
     N = size(nodes,1);
 
     A = spalloc(N,N,0);
+
+    n_of_tetra_faces = 4;
 
     % Start constructing the elements of 𝐴 iteratively. Summing the integrands
     % ∇ψⱼ ⋅ (𝑇∇ψᵢ) multiplied by volume elements d𝑉 like this corresponds to
     % integration.
 
-    for i = 1 : 4
+    for i = 1 : n_of_tetra_faces
 
         grad_1 = zef_volume_gradient(nodes, tetrahedra, i);
 
-        for j = i : 4
+        for j = i : n_of_tetra_faces
 
             if i == j
                 grad_2 = grad_1;
@@ -115,5 +122,13 @@ function A = zef_stiffness_matrix(nodes, tetrahedra, volume, tensor)
 
             end
         end
+
+        wbi = wbi + 1;
+        waitbar(wbi / n_of_tetra_faces, wb);
+
     end
+
+    waitbar(1,wb);
+    close(wb)
+
 end

--- a/m/operators/zef_stiffness_matrix.m
+++ b/m/operators/zef_stiffness_matrix.m
@@ -129,6 +129,6 @@ function A = zef_stiffness_matrix(nodes, tetrahedra, volume, tensor)
     end
 
     waitbar(1,wb);
-    close(wb)
+    close(wb);
 
 end


### PR DESCRIPTION
These commits add waitbars to `zef_stiffness_matrix` and `zef_build_electrodes`. The function `zef_transfer_matrix` already had one. Also, the waitbar initalizations in `lead_field_eeg_fem`and `lead_field_tes_fem`were moved later into the scripts, so two waitbars would not be active at the same time.