### PR TITLE
zef_cem_electrode: added a check for empty input array

### DIFF
--- a/m/zef_cem_electrode.m
+++ b/m/zef_cem_electrode.m
@@ -1,6 +1,14 @@
 function s_points = zef_cem_electrode(s_points)
 
-current_sensors = evalin('base','zef.current_sensors');
-s_points = [s_points(:,1:3) evalin('base',['zef.' current_sensors '_electrode_outer_radius(:)']) evalin('base',['zef.' current_sensors '_electrode_inner_radius(:)']) evalin('base',['zef.' current_sensors '_electrode_impedance(:)'])];
-
+    if isempty(s_points)
+        s_points = [];
+    else
+        current_sensors = evalin('base','zef.current_sensors');
+        s_points = [ ...
+            s_points(:,1:3), ...
+            evalin('base',['zef.' current_sensors '_electrode_outer_radius(:)']), ...
+            evalin('base',['zef.' current_sensors '_electrode_inner_radius(:)']), ...
+            evalin('base',['zef.' current_sensors '_electrode_impedance(:)']) ...
+        ];
+    end
 end


### PR DESCRIPTION
Also added a few line breaks, commas and line continuations `...` inside the
non-empty branch of the input array check, in the generation of the output
variable `s_points`, to make the code more readable. Commas with line
continuations generate a row vector the same way that white space does.