### PR TITLE
Segmentation tool: fix (un)setting of empty compartment tickboxes during startup

### DIFF
--- a/m/zef_import_segmentation_legacy.m
+++ b/m/zef_import_segmentation_legacy.m
@@ -364,6 +364,10 @@ end
 
 end
 
+if isempty(evalin('base',['zef.' name_cell{j} '_points']))
+evalin('base',['zef.' name_cell{j} '_on = 0;']);
+end
+
 end
 
 %*****************************

--- a/m/zef_load.m
+++ b/m/zef_load.m
@@ -51,7 +51,7 @@ zef_data.mlapp = 1;
  zef_init_init_profile;
  zef_init_parameter_profile;
 
-if ismember(zef.start_mode,{'nodisplay','display'})
+if ismember(zef.start_mode,{'nodisplay'})
 zef.use_display = 0;
 end
 

--- a/m/zef_remove_system_fields.m
+++ b/m/zef_remove_system_fields.m
@@ -1,4 +1,4 @@
-zef.system_fields = {'compartment_activity'};
+zef.system_fields = {'compartment_activity','start_mode'};
 for zef_i  =  1 : length(zef.system_fields)
 if isfield(zef_data,zef.system_fields{zef_i});
 zef_data = rmfield(zef_data,zef.system_fields{zef_i});

--- a/m/zeffiro_interface_segmentation_tool.m
+++ b/m/zeffiro_interface_segmentation_tool.m
@@ -62,10 +62,10 @@ set(zef.h_menu_export_sensors                     ,'MenuSelectedFcn','zef.save_s
 set(zef.h_menu_export_reconstruction                        ,'MenuSelectedFcn','zef.save_switch=8;zef_save;zef_update;');
 
 set(zef.h_menu_new_segmentation_from_folder_legacy          ,'MenuSelectedFcn','[zef.yesno] = questdlg(''Reset and import a segmentation from folder?'',''Yes'',''No''); if isequal(zef.yesno,''Yes'');zef.new_empty_project = 0;zef_start_new_project; zef_import_segmentation_legacy;zef_build_compartment_table;end;');
-set(zef.h_menu_import_segmentation_update_from_folder_legacy,'MenuSelectedFcn','zef.new_empty_project = 0;zef_import_segmentation_legacy;zef_update;');
+set(zef.h_menu_import_segmentation_update_from_folder_legacy,'MenuSelectedFcn','zef.new_empty_project = 0;zef_import_segmentation_legacy;zef_build_compartment_table;');
 
 set(zef.h_menu_new_segmentation_from_folder          ,'MenuSelectedFcn','[zef.yesno] = questdlg(''Reset and import a segmentation from folder?'',''Yes'',''No''); if isequal(zef.yesno,''Yes'');zef.new_empty_project = 1;zef_start_new_project; zef_import_segmentation;zef_build_compartment_table;end;');
-set(zef.h_menu_import_segmentation_update_from_folder,'MenuSelectedFcn','zef.new_empty_project = 0;zef_import_segmentation;zef_update;');
+set(zef.h_menu_import_segmentation_update_from_folder,'MenuSelectedFcn','zef.new_empty_project = 0;zef_import_segmentation;');
 
 set(zef.h_menu_import_new_project_from_folder        ,'MenuSelectedFcn','[zef.yesno] = questdlg(''Reset and import a project from folder?'',''Yes'',''No''); if isequal(zef.yesno,''Yes'');zef_start_new_project; zef_import_project;zef_build_compartment_table;end;');
 set(zef.h_menu_import_project_update_from_folder    ,'MenuSelectedFcn','zef_import_project;zef_update;');

--- a/zeffiro_interface.m
+++ b/zeffiro_interface.m
@@ -115,7 +115,7 @@ function zeffiro_interface(varargin)
                 assignin('base','zef_data',zef_data);
                 evalin('base','zef_assign_data;');
                 clear zef_data;
-                evalin('base','zef_start_new_project;zef_import_segmentation');
+                evalin('base','zef_start_new_project;zef_import_segmentation;zef_build_compartment_table;');
                 option_counter = option_counter + 2;
 
             elseif isequal(varargin{option_counter},lower('import_update'))
@@ -161,7 +161,7 @@ function zeffiro_interface(varargin)
                 assignin('base','zef_data',zef_data);
                 evalin('base','zef_assign_data;');
                 clear zef_data;
-                evalin('base','zef_start_new_project:zef_import_segmentation_legacy');
+                evalin('base','zef_start_new_project;zef_import_segmentation_legacy;zef_build_compartment_table;');
                 option_counter = option_counter + 2;
 
             elseif isequal(varargin{option_counter},lower('import_segmentation_update_legacy'))
@@ -184,7 +184,7 @@ function zeffiro_interface(varargin)
                 assignin('base','zef_data',zef_data);
                 evalin('base','zef_assign_data;');
                 clear zef_data;
-                evalin('base','zef_import_segmentation_legacy');
+                evalin('base','zef_import_segmentation_legacy;zef_build_compartment_table;');
                 option_counter = option_counter + 2;
 
             elseif isequal(varargin{option_counter},lower('save_project'))


### PR DESCRIPTION
This consists of the following 5 changes.

1. zef_import_segmentation_legacy: empty compartment cells deactivated

   Added a conditional statement that deactivates the selection of empty
   brain compartments.

2. zef_load: only deactivate display, if nodisplay is set in startup options

3. zef_remove_system_fields: added start_mode to system fields

   Now start_mode is properly reset during startup.

4. zeffiro_interface_segmentation_tool: removed calls to zef_update

   This prevents the unintended activation of checkboxes related to loaded
   but empty brain compartments.

5. zeffiro_interface: added calls to zef_build_compartment_table

   Now the segmentation tool compartment GUI should be built properly.