### PR TITLE
Check sign of lead field in x-, y- and z-directions separately

### DIFF
--- a/m/forward_scripts/brain/lead_field_eeg_fem.m
+++ b/m/forward_scripts/brain/lead_field_eeg_fem.m
@@ -236,9 +236,5 @@ L_eeg = T' * G;
 
 L_eeg = L_eeg - mean(L_eeg, 1);
 
-% Make sure lead field has correct orientation
-
-L_eeg = zef_lead_field_sign(dipole_locations, electrodes, L_eeg) * L_eeg;
-
 end % if
 end % function

--- a/m/forward_scripts/brain/lead_field_matrix.m
+++ b/m/forward_scripts/brain/lead_field_matrix.m
@@ -125,19 +125,36 @@ zef = rmfield(zef,{'nodes_aux','sensors_aux','aux_vec','aux_vec_sources'});
 zef.lead_field_time = toc;
 
 if zef.location_unit == 1
-zef.source_positions = 1000*zef.source_positions;
-zef.location_unit_current = 1;
+    zef.source_positions = 1000*zef.source_positions;
+    zef.location_unit_current = 1;
 end
 
 if zef.location_unit == 2
-zef.source_positions = 100*zef.source_positions;
-zef.location_unit_current = 2;
+    zef.source_positions = 100*zef.source_positions;
+    zef.location_unit_current = 2;
 end
 
 if zef.location_unit == 3
-zef.location_unit_current = 3;
+    zef.location_unit_current = 3;
 end
 
 if zef.source_interpolation_on
-[zef.source_interpolation_ind] = source_interpolation([]);
+    [zef.source_interpolation_ind] = source_interpolation([]);
+end
+
+% Flip EEG lead field signs per cartesian basis direction, if they are not
+% correct.
+%
+% NOTE: previously this was located in lead_field_eeg_fem, before the source
+% interpolation and unit scaling above, but either the above scaling or
+% interpolation caused the sign of the x-columns of L(1:3:end) to get flipped.
+
+if zef.lead_field_type == 1
+
+    [Lsignx, Lsigny, Lsignz] = zef_lead_field_sign(zef.source_positions, zef.sensors(:,1:3), zef.L);
+
+    zef.L(:, 1:3:end) = Lsignx * zef.L(:, 1:3:end);
+    zef.L(:, 2:3:end) = Lsigny * zef.L(:, 2:3:end);
+    zef.L(:, 3:3:end) = Lsignz * zef.L(:, 3:3:end);
+
 end


### PR DESCRIPTION
Also, the sign check was moved to the end of `lead_field_matrix` from
`lead_field_eeg_fem`, because the source interpolation after at the end of
`lead_field_matrix` caused yet another sign flip.

The individual commit messages of this squashed set of commits can be found
below. Don't forget to see the attached diff as well before accepting the pull
request.

-----------------------------

- Updated function `zef_lead_field_sign` to calculate the signs of the lead
field in x-, y- and z-directions separately.

- The function `lead_field_eeg_fem` multiplies the columns of `L_eeg`
corresponding to these directions to ensure correct `L_eeg` orientation.

Moved EEG lead field sign flip(s) to the end of lead_field_matrix from lead_field_eeg_fem

zef_lead_field_sign: ensure the test electrodes are in the direction the test source dipoles point to

zef_lead_field_sign: improved documentation