### PR TITLE
Removed sign flip from end of lead_field_matrix.m

### DIFF
--- a/m/forward_scripts/brain/lead_field_matrix.m
+++ b/m/forward_scripts/brain/lead_field_matrix.m
@@ -141,20 +141,3 @@ end
 if zef.source_interpolation_on
     [zef.source_interpolation_ind] = source_interpolation([]);
 end
-
-% Flip EEG lead field signs per cartesian basis direction, if they are not
-% correct.
-%
-% NOTE: previously this was located in lead_field_eeg_fem, before the source
-% interpolation and unit scaling above, but either the above scaling or
-% interpolation caused the sign of the x-columns of L(1:3:end) to get flipped.
-
-if zef.lead_field_type == 1
-
-    [Lsignx, Lsigny, Lsignz] = zef_lead_field_sign(zef.source_positions, zef.sensors(:,1:3), zef.L);
-
-    zef.L(:, 1:3:end) = Lsignx * zef.L(:, 1:3:end);
-    zef.L(:, 2:3:end) = Lsigny * zef.L(:, 2:3:end);
-    zef.L(:, 3:3:end) = Lsignz * zef.L(:, 3:3:end);
-
-end


### PR DESCRIPTION
This was still left over from the last merged pull request by Santtu. Again, please have a quick look at the changed files in the pull request tab of the same name before merging.