### PR TITLE
Added a free-form parameter

### DIFF
--- a/m/zef_get_profile_parameters.m
+++ b/m/zef_get_profile_parameters.m
@@ -1,6 +1,7 @@
 function [name_cell, variable_cell] = zef_get_profile_parameters(zef,varargin)
 
 parameter_index = [];
+
 if not(isempty(varargin))
     parameter_index = varargin{1};
 end
@@ -8,17 +9,20 @@ end
 parameter_profile = eval('zef.parameter_profile');
 
 zef_n = 0;
+
 for zef_k =  1  : size(parameter_profile,1)
-     if isequal(parameter_profile{zef_k,8},'Segmentation') && isequal(parameter_profile{zef_k,6},'On') && isequal(parameter_profile{zef_k,3},'Scalar')
-  zef_n = zef_n + 1;
-     name_cell{zef_n} = parameter_profile{zef_k,1};
-    variable_cell{zef_n} = ['zef.' parameter_profile{zef_k,2}];
+    if ismember(parameter_profile{zef_k,8},{'Segmentation', 'Free-form'}) ...
+    && isequal(parameter_profile{zef_k,6},'On') ...
+    && isequal(parameter_profile{zef_k,3},'Scalar')
+       zef_n = zef_n + 1;
+       name_cell{zef_n} = parameter_profile{zef_k,1};
+       variable_cell{zef_n} = ['zef.' parameter_profile{zef_k,2}];
     end
 end
 
 if not(isempty(parameter_index))
-name_cell = name_cell{parameter_index};
-variable_cell = variable_cell{parameter_index};
+    name_cell = name_cell{parameter_index};
+    variable_cell = variable_cell{parameter_index};
 end
 
 end

--- a/m/zef_open_parameter_profile.m
+++ b/m/zef_open_parameter_profile.m
@@ -5,7 +5,7 @@ zef.h_parameter_profile_table.Data = readcell([zef.program_path '/profile/' zef.
 
 set(zef.h_parameter_profile_table,'CellSelectionCallback',@zef_parameter_profile_table_selection);
 
-set(zef.h_parameter_profile_table,'columnformat',{'char','char',{'Scalar','String'},'char','char',{'On','Off'},{'On','Off'},{'Segmentation','Sensors'}});
+set(zef.h_parameter_profile_table,'columnformat',{'char','char',{'Scalar','String'},'char','char',{'On','Off'},{'On','Off'},{'Segmentation','Sensors', 'Free-form'}});
 
 set(zef.h_parameter_profile_from_project,'ButtonPushedFcn','zef.h_parameter_profile_table.Data = zef.parameter_profile;');
 

--- a/profile/multicompartment_head/zeffiro_parameters.ini
+++ b/profile/multicompartment_head/zeffiro_parameters.ini
@@ -2,6 +2,7 @@ Electrical conductivity,sigma,Scalar,0.33,S/m,On,On,Segmentation
 Mass density,rho,Scalar,2000,kg/m3,Off,On,Segmentation
 Dielectric permittivity,epsilon,Scalar,1,Rel.,Off,On,Segmentation
 Magnetic permeability,mu,Scalar,1,Rel.,Off,On,Segmentation
+Filter labels,filtered_tetra,Scalar,0,Rel.,On,Off,Free form
 Elecctrode impedance,electrode_impedance,Scalar,2000,Ohm,On,On,Sensors
 Elecctrode outer radius,electrode_outer_radius,Scalar,0,mm,On,On,Sensors
 Elecctrode inner radius,electrode_inner_radius,Scalar,1,mm,On,On,Sensors


### PR DESCRIPTION
The point is to prevent ZI from unintentionally overwriting the parameters one
wishes to display in the Figure tool, which it does with the parameter
profiles Segmentation and Sensors, when displayed parameters are set in Mesh
Visualization Tool.