### PR TITLE
Add a .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,32 @@
+## Git Attributes
+#
+# This file contains specifications that make Git automatically make certain
+# edits to text files, before they are added to the working tree (the set of
+# tracked files). The conversions include changing Windows line endings
+# <CR><LF> to Unix equivalents <LF>, so that text files would contain less
+# clutter on such systems.
+#
+# File types not listed here will not be tampered with, unless your local Git
+# configuration file instructs Git to do so. By default it does not do it for
+# any files.
+
+# Declare text files, whose line endings will be normalized.
+
+*.txt   text eol=lf
+*.asc   text eol=lf
+*.md    text eol=lf
+*.zef   text eol=lf
+*.m     text eol=lf
+*.sh    text eol=lf
+README  text eol=lf
+
+# Then declare binary files to indicate which files should absolutely not be
+# touched, even if a user wants to.
+
+*.pdf    binary
+*.png    binary
+*.jpg    binary
+*.mlapp  binary
+*.fig    binary
+*.mat    binary
+*.stl    binary

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # Allow specific files
 
 !.gitignore
+!.gitattributes
 !LICENSE
 
 # Allow file types (in subfolders) with a !


### PR DESCRIPTION
This file tells Git to change the line endings in newly added text files to a
simple Line Feed <LF> instead of the Windows equivalent <CR><LF>, as the files
are added to the working tree (the set of files that Git is keeping track of)
in this repository. This makes the reading experience of Unix users a bit more
pleasant. The line feeds are converted back to <CR><LF> on Windows as they are
checked out for local editing. Binary files such as mlapp are ignored and not
modified.

---------------------------------

Allowed .gitattributes

Added an initial .gitattributes file

Explicitly declare line ending type for text files

Added text attribute to README

Added the binary attribute to .fig files

Added the text attribute to .asc files

Added the binary attribute to .mat and .stl files

Fixed typo in comment and added a spaces between file spec and binary attributes