### PR TITLE
Add external libraries as git submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # Allow specific files
 
 !.gitignore
+!.gitmodules
 !.gitattributes
 !LICENSE
 !CONTRIBUTING.md

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,12 @@
+[submodule "external/CVX"]
+	path = external/CVX
+	url = https://github.com/cvxr/CVX.git
+[submodule "external/SDPT3"]
+	path = external/SDPT3
+	url = https://github.com/sqlp/sdpt3.git
+[submodule "external/SeDuMi"]
+	path = external/SeDuMi
+	url = https://github.com/sqlp/sedumi.git
+[submodule "external/SESAME"]
+	path = external/SESAME
+	url = https://github.com/i-am-sorri/SESAME_core.git

--- a/external/README.md
+++ b/external/README.md
@@ -1,0 +1,25 @@
+# External libraries
+
+This folder contains external libraries such as third party optimizers (mostly
+as Git submodules), that might be called by Zeffiro Interface. These can be
+installed alongside Zeffiro Interface with
+
+	git clone --recurse-submodules https://github.com/sampsapursiainen/zeffiro_interface.git
+
+or
+
+	git clone --recursive https://github.com/sampsapursiainen/zeffiro_interface.git
+
+and then running
+
+	zeffiro_setup
+
+in the Matlab console to run their installation scripts.
+
+Even if Zeffiro was downloaded without recursively installing the submodules,
+for example by downloading the program as an archive file or Git cloning
+unrecursively,
+
+	zeffiro_setup
+
+should still do the downloading of the modules for you.

--- a/zeffiro_setup.m
+++ b/zeffiro_setup.m
@@ -5,22 +5,27 @@ zef_data.fid_temp = fopen([fileparts(mfilename('fullpath')) filesep 'm' filesep 
 fprintf(zef_data.fid_temp, ['warning off;']);
 mkdir(fileparts(mfilename('fullpath')),'external');
 
+% Download the external libraries to the folders specified in the .gitmodules
+% file.
+
+!git submodule update --init --recursive
+
 %%% Install SDPT3 BEGIN %%%
-eval(['!git clone https://github.com/sqlp/sdpt3 ' fileparts(mfilename('fullpath')) filesep 'external/SDPT3'])
+%eval(['!git clone https://github.com/sqlp/sdpt3 ' fileparts(mfilename('fullpath')) filesep 'external/SDPT3'])
 run([fileparts(mfilename('fullpath')) filesep '/external/SDPT3/install_sdpt3.m']);
 zef_data.str_temp = 'if isequal(zef.zeffiro_restart, 0), addpath([zef.program_path filesep ''/external/SDPT3/'']); end';
 fprintf(zef_data.fid_temp, ['\n' zef_data.str_temp]);
 %%% Install SDPT3 END %%%
 
 %%% Install SeDuMi BEGIN %%%
-eval(['!git clone https://github.com/sqlp/sedumi ' fileparts(mfilename('fullpath')) filesep 'external/SeDuMi'])
+%eval(['!git clone https://github.com/sqlp/sedumi ' fileparts(mfilename('fullpath')) filesep 'external/SeDuMi'])
 run([fileparts(mfilename('fullpath')) filesep '/external/SeDuMi/install_sedumi.m']);
 zef_data.str_temp = 'if isequal(zef.zeffiro_restart, 0), addpath([zef.program_path filesep ''/external/SeDuMi/'']); end';
 fprintf(zef_data.fid_temp, ['\n' zef_data.str_temp]);
 %%% Install SeDuMi END %%%
 
 %%% Install CVX BEGIN %%%
-eval(['!git clone https://github.com/cvxr/CVX ' fileparts(mfilename('fullpath')) filesep 'external/CVX'])
+%eval(['!git clone https://github.com/cvxr/CVX ' fileparts(mfilename('fullpath')) filesep 'external/CVX'])
 run([fileparts(mfilename('fullpath')) filesep '/external/CVX/cvx_setup.m']);
 zef_data.str_temp = 'if isequal(zef.zeffiro_restart, 0), addpath([zef.program_path filesep ''/external/CVX/'']); end';
 fprintf(zef_data.fid_temp, ['\n' zef_data.str_temp]);
@@ -29,7 +34,7 @@ fprintf(zef_data.fid_temp, ['\n' zef_data.str_temp]);
 %%% Install CVX BEGIN %%%
 
 %%% Install SESAME BEGIN %%%
-eval(['!git clone https://github.com/i-am-sorri/SESAME_core ' fileparts(mfilename('fullpath')) filesep 'external/SESAME'])
+%eval(['!git clone https://github.com/i-am-sorri/SESAME_core ' fileparts(mfilename('fullpath')) filesep 'external/SESAME'])
 zef_data.str_temp = 'if isequal(zef.zeffiro_restart, 0), addpath([zef.program_path filesep ''/external/SESAME/'']); end';
 %%% Install SESAME END %%%
 


### PR DESCRIPTION
This simplifies the installation process somewhat, and also makes the lives of Git users easier. Now the (free) dependencies can be installed with a simple

	git submodule update --init --recursive

or in conjunction with downloading Zeffiro Interface with

	git clone --recurse-submodules https://github.com/sampsapursiainen/zeffiro_interface.git

or

	git clone --recursive https://github.com/sampsapursiainen/zeffiro_interface.git

and then running

	zeffiro_setup

in the Matlab console to run the installation scripts of the dependencies in a single batch.

This is a squashed commit that closes #156. Individual commit messages can be seen below.

------------------------------------------------------

.gitignore: allowed the file .gitmodules

Removed external/CVX folder from index

Added external/CVX as a submodule

Removed external/SDPT3 from index

Added external/SDPT3 as a submodule

Remove external/SeDuMi before adding it as submodule

Add external/SeDuMi as a submodule

zeffiro_setup: comment out git clones of the external libraries

These should be downloaded with

	git submodule update --init --recursive

instead. Will probably add the above command later.

Removed external/SESAME before adding it as a proper submodule

Added external/SESAME as a proper submodule

zeffiro_setup: call "git submodule --init --recursive" to download submodules

Add external/README.md

Contains instructions on installing the third-party dependencies.

external/README: fixed a typo