### PR TITLE
Change sensitivity scripts to a more batch job -friendly form, as in into functions

### DIFF
--- a/scripts/specialized/inverse_sensitivity/inverse_sensitivity_fn.m
+++ b/scripts/specialized/inverse_sensitivity/inverse_sensitivity_fn.m
@@ -1,0 +1,198 @@
+function sensitivities_with_statistics = inverse_sensitivity_fn( ...
+    project_path, ...
+    inverse_method, ...
+    mesh_resolution, ...
+    n_of_sources, ...
+    n_of_runs, ...
+    noise_level_db, ...
+    diff_type, ...
+    args ...
+)
+
+    %
+    % inverse_sensitivity_fn
+    %
+    % Computes normed distance, direction and magnitude differences between
+    % given project dipoles and their reconstructions, determined by a given
+    % inverse method name.
+    %
+    % Inputs:
+    %
+    % - project_path
+    %
+    %   The project for which a FE mesh, alead field and source locations are
+    %   to be constructed.
+    %
+    % - inverse_method
+    %
+    %   The name of an inverse method as a string. Valid names are "sLORETA",
+    %   "dSPM", "MNE" and "Dipole Scan".
+    %
+    % - mesh_resolution
+    %
+    %   The resolution of the mesh that will be constructed based on the
+    %   project_path.
+    %
+    % - n_of_sources
+    %
+    %   The number of sources that are to be injected into the active brain
+    %   compartments, and according to which the lead field will be computed.
+    %
+    % - n_of_runs
+    %
+    %   The number of reconstructions that will be constructed for statistical
+    %   purposes. Multiple are needed, if noise is added to the model via...
+    %
+    % - noise_level_db
+    %
+    %   The assumed noise level that is to be used when inverting the computed
+    %   lead field.
+    %
+    % - diff_type
+    %
+    %   One of "L2" or "minabs". Determines how the position difference
+    %   metrics between reconstructions and the original dipoles are computed.
+    %
+    % - args.use_gpu
+    %
+    %   A name–value argument which determines whether a GPU will be used to
+    %   perform the relevant computations (if available).
+    %
+    % Output:
+    %
+    % - sensitivities_with_statistics
+    %
+    %   The computed sensitivities or differences between positions,
+    %   orientations and magnitudes of the source and inverted dipoles.
+    %
+
+    arguments
+
+        project_path (1,:) char
+
+        inverse_method (1,:) char { mustBeMember(inverse_method, ["sLORETA", "dSPM", "MNE", "Dipole Scan"]) }
+
+        mesh_resolution (1,1) double { mustBeReal, mustBePositive }
+
+        n_of_sources (1,1) double { mustBeInteger, mustBePositive }
+
+        n_of_runs (1,1) double { mustBeInteger, mustBePositive }
+
+        noise_level_db (1,1) double { mustBeNonpositive } = -30
+
+        diff_type (1,1) string { mustBeMember(diff_type, ["L2", "minabs"]) } = "L2"
+
+        args.use_gpu (1,1) logical = false;
+
+    end
+
+    % Load an initial project struct from the given path.
+
+    project_struct = zeffiro_interface( ...
+        'start_mode','nodisplay', ...
+        'use_github', false, ...
+        'use_gpu', args.use_gpu, ...
+        'open_project', project_path ...
+    );
+
+    % Set mesh resolution and generate a finite element mesh.
+
+    project_struct.mesh_resolution = mesh_resolution;
+
+    % This is disabled for now, so that the pre-existing mesh stored on Puhti
+    % is used as-is.
+    %
+    % project_struct = zef_create_finite_element_mesh(project_struct);
+
+    % Set the number of (dipolar) sources to be reconstructed.
+
+    project_struct.n_sources = n_of_sources;
+
+    project_struct = zef_eeg_lead_field(project_struct);
+
+    % Start the MNE tool and calculate reconstruction sensitivities for the
+    % given MNE type.
+
+    project_struct = zef_minimum_norm_estimation(project_struct);
+
+    if inverse_method == "sLORETA" ...
+    || inverse_method == "dSPM" ...
+    || inverse_method == "MNE" ...
+
+        sensitivities = zef_sensitivity_map_mne(project_struct, inverse_method, n_of_runs, noise_level_db, diff_type);
+
+    elseif inverse_method == "Dipole Scan"
+
+        sensitivities = zef_sensitivity_map_dipoleScan(project_struct, n_of_runs, noise_level_db, diff_type);
+
+    else
+
+        error("Unknown inverse method.")
+
+    end
+
+    sensitivities_with_statistics = add_statistics_to_struct(sensitivities, n_of_runs);
+
+end % function
+
+%% Local helper functions.
+
+function output_struct = add_statistics_to_struct(input_struct, n_reconstructions)
+
+    %
+    % add_statistics_to_struct
+    %
+    % Adds means and standard sample deviations to a given struct. Requires
+    % that the fields dist_vec, angle_vec and mag_vec are contained within
+    % the input struct.
+    %
+
+    arguments
+
+        input_struct (1,1) struct
+
+        n_reconstructions (1,1) double { mustBeInteger, mustBePositive }
+
+    end
+
+    % Preallocate space for the statistics.
+
+    input_struct.dist_vec_avg = zeros(size(input_struct.dist_vec{1}));
+    input_struct.angle_vec_avg = zeros(size(input_struct.angle_vec{1}));
+    input_struct.mag_vec_avg = zeros(size(input_struct.mag_vec{1}));
+
+    input_struct.dist_vec_std = zeros(size(input_struct.dist_vec{1}));
+    input_struct.angle_vec_std = zeros(size(input_struct.angle_vec{1}));
+    input_struct.mag_vec_std = zeros(size(input_struct.mag_vec{1}));
+
+    % Compute means.
+
+    for i = 1 : n_reconstructions
+
+        input_struct.dist_vec_avg = input_struct.dist_vec_avg + input_struct.dist_vec{i};
+        input_struct.angle_vec_avg = input_struct.angle_vec_avg + input_struct.angle_vec{i};
+        input_struct.mag_vec_avg = input_struct.mag_vec_avg + input_struct.mag_vec{i};
+
+    end
+
+    input_struct.dist_vec_avg = input_struct.dist_vec_avg/n_reconstructions;
+    input_struct.angle_vec_avg = input_struct.angle_vec_avg/n_reconstructions;
+    input_struct.mag_vec_avg = input_struct.mag_vec_avg/n_reconstructions;
+
+    % Compute standard deviations.
+
+    for i = 1 : n_reconstructions
+        input_struct.dist_vec_std = input_struct.dist_vec_std + (input_struct.dist_vec{i} - input_struct.dist_vec_avg).^2;
+        input_struct.angle_vec_std = input_struct.angle_vec_std + (input_struct.angle_vec{i} - input_struct.angle_vec_avg).^2;
+        input_struct.mag_vec_std = input_struct.mag_vec_std + (input_struct.mag_vec{i} - input_struct.mag_vec_avg).^2;
+    end
+
+    input_struct.dist_vec_std = sqrt(input_struct.dist_vec_std/(n_reconstructions-1));
+    input_struct.angle_vec_std = sqrt(input_struct.angle_vec_std/(n_reconstructions-1));
+    input_struct.mag_vec_std = sqrt(input_struct.mag_vec_std/(n_reconstructions-1));
+
+    % Everything succeeded, so set output value.
+
+    output_struct = input_struct;
+
+end

--- a/scripts/specialized/inverse_sensitivity/zef_rec_diff.m
+++ b/scripts/specialized/inverse_sensitivity/zef_rec_diff.m
@@ -45,7 +45,7 @@ function [dist_vec,angle_vec,mag_vec] = zef_rec_diff(zef, inverse_method, noise_
 
             if not(noise_db == 0)
 
-                zef.measurements(:,3*(i-1)+j) = 10^(-noise_db/20)*randn(size(zef.measurements,1),1) + zef.measurements(:,3*(i-1)+j);
+                zef.measurements(:,3*(i-1)+j) = 10^(noise_db/20)*randn(size(zef.measurements,1),1) + zef.measurements(:,3*(i-1)+j);
 
             end
 

--- a/scripts/specialized/inverse_sensitivity/zef_rec_diff.m
+++ b/scripts/specialized/inverse_sensitivity/zef_rec_diff.m
@@ -1,4 +1,4 @@
-function [dist_vec,angle_vec,mag_vec] = zef_rec_max_diff(zef, inverse_method, noise_db)
+function [dist_vec,angle_vec,mag_vec] = zef_rec_diff(zef, inverse_method, noise_db, diff_type)
 
     arguments
 
@@ -7,6 +7,8 @@ function [dist_vec,angle_vec,mag_vec] = zef_rec_max_diff(zef, inverse_method, no
         inverse_method (1,1) function_handle
 
         noise_db (1,1) double { mustBeNonpositive } = 0
+
+        diff_type (1,1) string { mustBeMember(diff_type, ["L2", "minabs"]) } = "L2"
 
     end
 
@@ -80,7 +82,21 @@ function [dist_vec,angle_vec,mag_vec] = zef_rec_max_diff(zef, inverse_method, no
             dir_vec_source = dir_mat(:,j);
             dir_vec_source = dir_vec_source/norm(dir_vec_source,2);
 
-            dist_vec(3*(i-1) + j) = (1/sqrt(3))*sqrt(sum((zef.source_positions(i,:) - zef.source_positions(I,:)).^2,2));
+            pos_diffs = zef.source_positions(i,:) - zef.source_positions(I,:);
+
+            if diff_type == "L2"
+
+                dist_vec(3*(i-1) + j) = (1/sqrt(3)) * sqrt(sum(pos_diffs.^2,2));
+
+            elseif diff_type == "minabs"
+
+                dist_vec(3*(i-1) + j) = (1/sqrt(3)) * min(abs(pos_diffs), [], 2);
+
+            else
+
+                error("Unknown comparison type in zef_rec_diff. Aborting...")
+
+            end
 
             angle_vec(3*(i-1) + j) = acosd(dot(dir_vec_rec,dir_vec_source));
 

--- a/scripts/specialized/inverse_sensitivity/zef_rec_min_diff.m
+++ b/scripts/specialized/inverse_sensitivity/zef_rec_min_diff.m
@@ -1,4 +1,4 @@
-function [dist_vec,angle_vec,mag_vec] = zef_rec_max_diff(zef, inverse_method, noise_db)
+function [dist_vec,angle_vec,mag_vec] = zef_rec_min_diff(zef, inverse_method, noise_db)
 
     arguments
 
@@ -75,12 +75,12 @@ function [dist_vec,angle_vec,mag_vec] = zef_rec_max_diff(zef, inverse_method, no
             [mag_val, I] = max(z_norm);
 
             dir_vec_rec = z_ij(3*(I-1)+1:3*(I-1)+3);
-            dir_vec_rec = dir_vec_rec/norm(dir_vec_rec,2);
+            dir_vec_rec = dir_vec_rec / norm(dir_vec_rec,2);
 
             dir_vec_source = dir_mat(:,j);
             dir_vec_source = dir_vec_source/norm(dir_vec_source,2);
 
-            dist_vec(3*(i-1) + j) = (1/sqrt(3))*sqrt(sum((zef.source_positions(i,:) - zef.source_positions(I,:)).^2,2));
+            dist_vec(3*(i-1) + j) = (1/sqrt(3)) * min(abs(zef.source_positions(i,:) - zef.source_positions(I,:)), [], 2);
 
             angle_vec(3*(i-1) + j) = acosd(dot(dir_vec_rec,dir_vec_source));
 

--- a/scripts/specialized/inverse_sensitivity/zef_sensitivity_map_dipoleScan.m
+++ b/scripts/specialized/inverse_sensitivity/zef_sensitivity_map_dipoleScan.m
@@ -1,50 +1,33 @@
-function hauk_map = zef_hauk_map_mne(project_struct, n_reconstructions, noise_level)
+function hauk_map = zef_sensitivity_map_dipoleScan(project_struct, n_reconstructions, noise_level, diff_type)
 
-  arguments
-        project_struct 
-        n_reconstructions = 10
-        noise_level = [-30]
-  end
-  
+    arguments
 
-hauk_map = struct;
+        project_struct (1,1) struct
 
-project_struct = zef_dipole_start(project_struct);
+        n_reconstructions (1,1) double { mustBeInteger, mustBePositive } = 10
 
-% 
-project_struct.number_of_frames = 3*size(project_struct.source_positions,1);
+        noise_level (1,1) double { mustBeNonpositive } = -30
 
-for i = 1 : n_reconstructions
-[hauk_map.dist_vec{i},hauk_map.angle_vec{i}, hauk_map.mag_vec{i}] = zef_rec_max_diff(project_struct,'zef_dipoleScan',noise_level);
-end
+        diff_type (1,1) string { mustBeMember(diff_type, ["L2", "minabs"]) } = "L2"
 
-hauk_map.dist_vec_avg = zeros(size(hauk_map.dist_vec{1}));
-hauk_map.angle_vec_avg = zeros(size(hauk_map.angle_vec{1}));
-hauk_map.mag_vec_avg = zeros(size(hauk_map.mag_vec{1}));
-
-hauk_map.dist_vec_std = zeros(size(hauk_map.dist_vec{1}));
-hauk_map.angle_vec_std = zeros(size(hauk_map.angle_vec{1}));
-hauk_map.mag_vec_std = zeros(size(hauk_map.mag_vec{1}));
-
-for i = 1 : n_reconstructions
-hauk_map.dist_vec_avg = hauk_map.dist_vec_avg + hauk_map.dist_vec{i};
-hauk_map.angle_vec_avg = hauk_map.angle_vec_avg + hauk_map.angle_vec{i};
-hauk_map.mag_vec_avg = hauk_map.mag_vec_avg + hauk_map.mag_vec{i};
-end
-
-hauk_map.dist_vec_avg = hauk_map.dist_vec_avg/n_reconstructions;
-hauk_map.angle_vec_avg = hauk_map.angle_vec_avg/n_reconstructions;
-hauk_map.mag_vec_avg = hauk_map.mag_vec_avg/n_reconstructions;
-
-for i = 1 : n_reconstructions
-hauk_map.dist_vec_std = hauk_map.dist_vec_std + (hauk_map.dist_vec{i} - hauk_map.dist_vec_avg).^2;
-hauk_map.angle_vec_std = hauk_map.angle_vec_std + (hauk_map.angle_vec{i} - hauk_map.angle_vec_avg).^2;
-hauk_map.mag_vec_std = hauk_map.mag_vec_std + (hauk_map.mag_vec{i} - hauk_map.mag_vec_avg).^2;
-end
-
-hauk_map.dist_vec_std = sqrt(hauk_map.dist_vec_std/(n_reconstructions-1));
-hauk_map.angle_vec_std = sqrt(hauk_map.angle_vec_std/(n_reconstructions-1));
-hauk_map.mag_vec_std = sqrt(hauk_map.mag_vec_std/(n_reconstructions-1));
+    end
 
 
-end
+    hauk_map = struct;
+
+    project_struct = zef_dipole_start(project_struct);
+
+    project_struct.number_of_frames = 3*size(project_struct.source_positions,1);
+
+    for i = 1 : n_reconstructions
+
+        [hauk_map.dist_vec{i},hauk_map.angle_vec{i}, hauk_map.mag_vec{i}] = zef_rec_diff( ...
+            project_struct, ...
+            @zef_dipoleScan, ...
+            noise_level, ...
+            diff_type ...
+        );
+
+    end
+
+end % function

--- a/scripts/specialized/inverse_sensitivity/zef_sensitivity_map_mne.m
+++ b/scripts/specialized/inverse_sensitivity/zef_sensitivity_map_mne.m
@@ -1,41 +1,48 @@
-function sensitivity_map = zef_sensitivity_map_mne(project_struct, weighting_type, n_reconstructions, noise_level)
+function sensitivity_map = zef_sensitivity_map_mne(project_struct, weighting_type, n_reconstructions, noise_level, diff_type)
 
-  arguments
-      project_struct 
-        weighting_type = 'sLORETA'
-        n_reconstructions = 10
-        noise_level = [-30]
-  end
-  
-  weighting_type_cell = {'mne','dspm','sloreta'};
-  weighting_type = find(ismember(weighting_type_cell,lower(weighting_type)));
+    arguments
 
-sensitivity_map = struct;
-sensitivity_map.weighting_type = weighting_type_cell{weighting_type}; 
+        project_struct (1,1) struct
 
-project_struct = zef_minimum_norm_estimation(project_struct);
+        weighting_type  (1,:) char { mustBeMember(weighting_type, ['sLORETA', 'dSPM', 'MNE']) } = 'sLORETA'
 
-% 
-project_struct.mne_number_of_frames = 3*size(project_struct.source_positions,1);
-project_struct.mne_type = weighting_type;
+        n_reconstructions (1,1) double { mustBeInteger, mustBePositive } = 10
 
-for i = 1 : n_reconstructions
-[sensitivity_map.dist_vec{i},sensitivity_map.angle_vec{i}, sensitivity_map.mag_vec{i}] = zef_rec_max_diff(project_struct,'zef_find_mne_reconstruction',noise_level);
-end
+        noise_level (1,1) double { mustBeNonpositive } = -30
 
-sensitivity_map.dist_vec_avg = zeros(size(sensitivity_map.dist_vec{1}));
-sensitivity_map.angle_vec_avg = zeros(size(sensitivity_map.angle_vec{1}));
-sensitivity_map.mag_vec_avg = zeros(size(sensitivity_map.mag_vec{1}));
+        diff_type (1,1) string { mustBeMember(diff_type, ["L2", "minabs"]) } = "L2"
 
-for i = 1 : n_reconstructions
-sensitivity_map.dist_vec_avg = sensitivity_map.dist_vec_avg + sensitivity_map.dist_vec{i};
-sensitivity_map.angle_vec_avg = sensitivity_map.angle_vec_avg + sensitivity_map.angle_vec{i};
-sensitivity_map.mag_vec_avg = sensitivity_map.mag_vec_avg + sensitivity_map.mag_vec{i};
-end
+    end
 
-sensitivity_map.dist_vec_avg = sensitivity_map.dist_vec_avg/n_reconstructions;
-sensitivity_map.angle_vec_avg = sensitivity_map.angle_vec_avg/n_reconstructions;
-sensitivity_map.mag_vec_avg = sensitivity_map.mag_vec_avg/n_reconstructions;
+    weighting_type_cell = {'MNE','dSPM','sLORETA'};
 
+    weighting_type_as_num = find(ismember(weighting_type_cell, weighting_type));
 
-end
+    % Set up the beginnings of a return value.
+
+    sensitivity_map = struct;
+
+    sensitivity_map.weighting_type = weighting_type;
+
+    project_struct = zef_minimum_norm_estimation(project_struct);
+
+    project_struct.mne_number_of_frames = 3*size(project_struct.source_positions,1);
+
+    project_struct.mne_type = weighting_type_as_num;
+
+    project_struct.mne_prior = 2;
+
+    % Call inverse method for a given number of times for averaging.
+
+    for i = 1 : n_reconstructions
+
+        [sensitivity_map.dist_vec{i},sensitivity_map.angle_vec{i}, sensitivity_map.mag_vec{i}] = zef_rec_diff( ...
+            project_struct, ...
+            @zef_find_mne_reconstruction, ...
+            noise_level, ...
+            diff_type ...
+        );
+
+    end
+
+end % function


### PR DESCRIPTION
What the title says. [Argument validation][argval] was also added. This is a squashed compilation of multiple commits. Individual commit messages can be seen below.

[argval]: https://se.mathworks.com/help/matlab/matlab_prog/function-argument-validation-1.html

-----------------------------------------------------------

Started cleaning up the functions that will be used to test for the sensitivity of inversion in the realistic head model case

Rename mne_sensitivity_fn to inverse_sensitivity_fn

Also allow passing in Dipole Scan as a possible inverse method

zef_sensitivity_map_dipoleScan: pass a function pointer to max diff function instead of a name of the function

inverse_sensitivity_fn: add input flag use_gpu

zef_sensitivity_map_dipoleScan: added argument validation functions

zef_sensitivity_map_mne: add missing standard deviation computations

Moved inverse_sensitivity_fn to the same location with the functions it uses

I wonder who moved the other functions in the first place?

Move averaging to the main inverse_sensitivity_fn

Added documentation to inverse_sensitivity_fn

Rename main function inside zef_sensitivity_map_dipoleScan to match the file name

zef_rec_max_diff: add some intermediate variable assignments for readability