### PR TITLE
Add reconstruction_from_edf_fn

### DIFF
--- a/scripts/scripts_for_importing/reconstruction_from_edf_fn.m
+++ b/scripts/scripts_for_importing/reconstruction_from_edf_fn.m
@@ -27,8 +27,8 @@ function [reconstruction, sample_rate, time_step, column_title_vec] = reconstruc
     %
     % - time_step
     %
-    %   The time step of each row in the timetable contained in the given
-    %   file.
+    %   The time step (seconds) of each row in the timetable contained in the
+    %   given file.
     %
     % - column_title_vec
     %

--- a/scripts/scripts_for_importing/reconstruction_from_edf_fn.m
+++ b/scripts/scripts_for_importing/reconstruction_from_edf_fn.m
@@ -1,0 +1,51 @@
+function reconstruction = reconstruction_from_edf_fn(path_to_file)
+
+    %
+    % reconstruction_from_edf_fn
+    %
+    % Reads an EDF or European Data Format file into a reconstruction
+    % compatible with Zeffiro Interface. Supposes that the sampling rate of
+    % each measurement has been constant, meaning each cell in the EDF table
+    % contains the same number of samples.
+    %
+
+    arguments
+
+        path_to_file (1,1) string { mustBeFile }
+
+    end
+
+    % First read the EDF file into a Matlab timetable.
+
+    timetable = edfread(path_to_file);
+
+    % Compute the needed size for the reconstruction matrix.
+
+    [n_of_rows, n_of_cols] = size(timetable);
+
+    upper_left_corner_cell = timetable{1,1};
+
+    upper_left_corner_series = upper_left_corner_cell{1,1};
+
+    cell_size = numel(upper_left_corner_series);
+
+    % Preallocate the reconstruction, with the idea that the timetable will be
+    % transposed.
+
+    reconstruction = zeros(n_of_cols, n_of_rows * cell_size);
+
+    % Then build the reconstruction by iterating over the timetable columns.
+
+    for col = 1 : n_of_cols
+
+        col_of_cells = timetable{:,col};
+
+        col_as_matrix = [col_of_cells{:}];
+
+        matrix_as_vector = col_as_matrix(:);
+
+        reconstruction(col,:) = matrix_as_vector;
+
+    end % for
+
+end % function

--- a/scripts/scripts_for_importing/reconstruction_from_edf_fn.m
+++ b/scripts/scripts_for_importing/reconstruction_from_edf_fn.m
@@ -1,4 +1,4 @@
-function reconstruction = reconstruction_from_edf_fn(path_to_file)
+function [reconstruction, sample_rate, time_step] = reconstruction_from_edf_fn(path_to_file)
 
     %
     % reconstruction_from_edf_fn
@@ -7,6 +7,28 @@ function reconstruction = reconstruction_from_edf_fn(path_to_file)
     % compatible with Zeffiro Interface. Supposes that the sampling rate of
     % each measurement has been constant, meaning each cell in the EDF table
     % contains the same number of samples.
+    %
+    % Input:
+    %
+    % - path_to_file
+    %
+    %   A textual path to the file. Must point to an existing file.
+    %
+    % Output:
+    %
+    % - reconstruction
+    %
+    %   The reconstruction matrix. Contains as its rows the electrode-specific
+    %   time series.
+    %
+    % - sample_rate
+    %
+    %   The number of samples in each cell of the given time table.
+    %
+    % - time_step
+    %
+    %   The time step of each row in the timetable contained in the given
+    %   file.
     %
 
     arguments
@@ -47,5 +69,11 @@ function reconstruction = reconstruction_from_edf_fn(path_to_file)
         reconstruction(col,:) = matrix_as_vector;
 
     end % for
+
+    % Set other return values.
+
+    time_step = seconds(timetable.Properties.TimeStep);
+
+    sample_rate = cell_size / time_step;
 
 end % function

--- a/scripts/scripts_for_importing/reconstruction_from_edf_fn.m
+++ b/scripts/scripts_for_importing/reconstruction_from_edf_fn.m
@@ -1,4 +1,4 @@
-function [reconstruction, sample_rate, time_step] = reconstruction_from_edf_fn(path_to_file)
+function [reconstruction, sample_rate, time_step, column_title_vec] = reconstruction_from_edf_fn(path_to_file)
 
     %
     % reconstruction_from_edf_fn
@@ -29,6 +29,11 @@ function [reconstruction, sample_rate, time_step] = reconstruction_from_edf_fn(p
     %
     %   The time step of each row in the timetable contained in the given
     %   file.
+    %
+    % - column_title_vec
+    %
+    %   The titles of the columns from the time table as a column vector of
+    %   strings.
     %
 
     arguments
@@ -75,5 +80,9 @@ function [reconstruction, sample_rate, time_step] = reconstruction_from_edf_fn(p
     time_step = seconds(timetable.Properties.TimeStep);
 
     sample_rate = cell_size / time_step;
+
+    column_title_cells = timetable.Properties.VariableNames';
+
+    column_title_vec = string(column_title_cells);
 
 end % function


### PR DESCRIPTION
This function reads an EDF or European Data Format file into a matrix that can be fed into `zef.reconstruction`. The rows contain time series data for each of the electrode columns in the file.