### PR TITLE
Fix line endings in zef_adaptive_grid_search_draft the second time

### DIFF
--- a/scripts/zef_adaptive_grid_search_draft.m
+++ b/scripts/zef_adaptive_grid_search_draft.m
@@ -2,7 +2,7 @@ function adapted_y_ES = zef_adaptive_grid_search_draft(varargin)
 %   adapted_y_ES returns an N-by-1 cell array of shrinking y_ES values
 %   using a finer grid search using a narrow hyperparameter range based on
 %   the initial exhaustive search produced by zef_ES_optimization.
-% 
+%
 %   The shrinkage begins at the optimal solution along with its M-by-M
 %   hyperparameters neighbors (if the optimal solution is located at the
 %   limits, the center of the window will be adjusted to match the grid).
@@ -15,7 +15,7 @@ function adapted_y_ES = zef_adaptive_grid_search_draft(varargin)
 %       evaluate the struct 'zef' which includes the hyperparameter values.
 %       The M size of the window and the N number of adaptive instances
 %       will automatically set by default. By default, if no zef struct is
-%       provided, it will be evaluated in the workspace. 
+%       provided, it will be evaluated in the workspace.
 %
 %   ----------------------
 %   Using [2] argument(s):
@@ -24,7 +24,7 @@ function adapted_y_ES = zef_adaptive_grid_search_draft(varargin)
 %       uses M as the size of the window, and N as the
 %       number of refined adaptive instances.
 %       The struct 'zef' will be evaluated in the workspace.
-% 
+%
 %   ----------------------
 %   Using [3] argument(s):
 %   ----------------------


### PR DESCRIPTION
This is just to normalize the line endings across the whole project. Looks like the documentation added to the function was written on a Windows machine, so these were added in that context.

The file `.gitattributes` should be preventing `crlf`s from making it into the repository by instructing Git to perform automatic changes from `crlf` to `lf` when new files are added to the index from the working tree (checked out commit/branch), but maybe some local Git configuration is overriding its effects. 🤷🏻‍♂️