### PR TITLE
Allow and add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+## .editorconfig
+#
+# This file instructs certain editors who know about its existence to always
+# perform certain actions like adding newlines of a certain style.
+#
+
+# Prevent looking for other .editorconfig files in the parent directories of
+# this project.
+
+root = true
+
+# Settings used by code and text files in this project.
+
+[*.{m,md,txt}]
+
+charset = utf-8
+
+indent_size = 4
+
+indent_style = space
+
+end_of_line = lf
+
+insert_final_newline = true
+
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 !.gitignore
 !.gitmodules
 !.gitattributes
+!.editorconfig
 !LICENSE
 !CONTRIBUTING.md
 


### PR DESCRIPTION
This file instructs editors that know about it to follow the instructions specified within. For example, newlines might be restricted to simple line feeds `lf` instead of carriage returns + line feeds `crlf`, which generate visual noise in Git diffs, as Git is whitespace aware in its default configuration.