### PR TITLE
Create bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Create a bug report to help us improve the app
+title: ''
+labels: 'bug'
+assignees: ''
+---
+
+## Description
+
+<!-- A clear and concise description of what the bug is. -->
+
+
+## Steps to reproduce
+
+<!-- Provide steps to reproduce the behavior as a numerated list -->
+
+1. 
+
+
+## Expected behavior
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+
+## Screenshots
+
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+
+## Context
+
+| Name | Value |
+| --- | --- |
+| **Version** | <!-- paste the `git log --oneline -n1 --no-decorate` output here --> |
+| **OS** | <!-- e.g. MacOS --> |
+| **Shell** | <!-- N/A, zsh, bash, etc --> |
+
+<!-- Add any other context about the problem here. -->


### PR DESCRIPTION
Add bug report template, to promote more elaborate bug descriptions and make all tickets to have similar format