### PR TITLE
utilities: add functions which save figures without colorbars

### DIFF
--- a/+utilities/figure_without_colorbar_fn.m
+++ b/+utilities/figure_without_colorbar_fn.m
@@ -1,0 +1,70 @@
+function figure_without_colorbar_fn(figtool, filename, filetypes, resolution)
+%
+% figure_without_colorbar_fn
+%
+% Saves a given Zeffiro Interface figure tool image without the colobar
+% included.
+%
+% Inputs:
+%
+%
+% - figtool (1,1) matlab.ui.Figure
+%
+%   An instace of a Zeffiro Interface Figure tool.
+%
+% - filename (1,1) string { mustBeValidVariableName }
+%
+%   The name of the saved file WITHOUT the suffix.
+%
+% - filetypes (:,1) string { mustBeMember ( filetypes, [".pdf", ".eps", ".png"] ) }
+%
+%   The list of file types that will be saved, given as a list of suffixes.
+%
+% - resolution
+%
+%   The resolution used for saving the image.
+%
+% Outputs:
+%
+% - None.
+%
+
+    arguments
+
+        figtool (1,1) matlab.ui.Figure
+
+        filename (1,1) string
+
+        filetypes (:,1) string { mustBeMember( filetypes, [".pdf", ".eps", ".png"] ) }
+
+        resolution (1,1) double { mustBePositive } = 400
+
+    end
+
+    if strlength ( filename ) == 0
+
+        error ( "A filname must not be empty. Call this function with a valid filename as the 2nd argument." ) ;
+
+    end
+
+    % Set visibility of all possible colorbars in the figure as off.
+
+    cbars = findobj ( figtool, "Type", "colorbar" ) ;
+
+    for bi = 1 : numel ( cbars )
+
+        cbar = cbars ( bi ) ;
+
+        cbar.Visible = false ;
+
+    end
+
+    for si = 1 : numel ( filetypes )
+
+        suffix = filetypes ( si ) ;
+
+        exportgraphics ( figtool, filename + suffix, "Resolution", resolution) ;
+
+    end
+
+end % functions

--- a/+utilities/figures_from_folder_without_colorbars_fn.m
+++ b/+utilities/figures_from_folder_without_colorbars_fn.m
@@ -1,0 +1,95 @@
+function figures_from_folder_without_colorbars(folder, filetypes, resolution)
+%
+% figures_from_folder_without_colorbars
+%
+% Collects the figures from a given folder, disables their colorbars and saves
+% them using utilities.figure_without_colorbar_fn.
+%
+% Inputs:
+%
+% - folder (1,1) string { mustBeFolder }
+%
+%   The folder from which the figure files are searched from.
+%
+% - filetypes (:,1) string { mustBeMember(filetypes, [".pdf",".eps",".png"]) }
+%
+%   The file extensions that are passed to figure_without_colorbar_fn, which
+%   does the actual saving.
+%
+% - resolution (1,1) double { mustBePositive }
+%
+%   The resolution the images will be save in, if PNG is used as output
+%   format.
+%
+
+    arguments
+
+        folder (1,1) string { mustBeFolder }
+
+        filetypes (:,1) string { mustBeMember(filetypes, [".pdf",".eps",".png"]) }
+
+        resolution (1,1) double { mustBePositive }
+
+    end
+
+    file_structs = dir ( fullfile ( folder, "**", "*.fig" ) ) ;
+
+    for si = 1 : numel ( file_structs )
+
+        file_struct = file_structs ( si ) ;
+
+        file_path = fullfile ( folder_fn ( file_struct ), name_fn ( file_struct ) ) ;
+
+        [stem, name, ext] = fileparts ( file_path ) ;
+
+        path_without_ext = fullfile ( stem, name ) ;
+
+        fig = openfig ( file_path ) ;
+
+        cleanup_fn = @(ff) close (ff) ;
+
+        cleanup_obj = onCleanup ( @() cleanup_fn ( fig ) ) ;
+
+        utilities.figure_without_colorbar_fn ( fig, path_without_ext, filetypes, resolution ) ;
+
+    end
+
+end % function
+
+%% Helper functions
+
+function name = name_fn(file_struct)
+
+    arguments
+
+        file_struct (1,1) struct
+
+    end
+
+    if not ( isfield ( file_struct, "name" ) )
+
+        error ( "The given file struct did not contain the field 'name'. Aborting..." ) ;
+
+    end
+
+    name = string ( file_struct.name ) ;
+
+end % function
+
+function folder = folder_fn(file_struct)
+
+    arguments
+
+        file_struct (1,1) struct
+
+    end
+
+    if not ( isfield ( file_struct, "folder" ) )
+
+        error ( "The given file struct did not contain the field 'folder'. Aborting..." ) ;
+
+    end
+
+    folder = string ( file_struct.folder ) ;
+
+end % function


### PR DESCRIPTION
- The functions are `figure_without_colorbar_fn` and `figures_from_folder_without_colorbars_fn`.

- The first one handles a single figure, and the second handles all figures in a given folder. The figures are opened, their colorbar visibilities are set to false and then the figures are saved and closed.