### PR TITLE
Add error handling to zef_start_config

### DIFF
--- a/m/zef_start_config.m
+++ b/m/zef_start_config.m
@@ -1,9 +1,90 @@
-warning off;
-if isequal(zef.zeffiro_restart, 0), addpath([zef.program_path filesep '/external/SDPT3/']); end
-if isequal(zef.zeffiro_restart, 0), addpath([zef.program_path filesep '/external/SeDuMi/']); end
-if isequal(zef.zeffiro_restart, 0), addpath([zef.program_path filesep '/external/CVX/']); end
-if isequal(zef.zeffiro_restart, 0), evalc('cvx_startup'); end
-if isequal(zef.zeffiro_restart, 0), addpath([zef.program_path filesep '/external/fieldtrip/']); end
-if isequal(zef.zeffiro_restart, 0), evalc('ft_defaults'); end
-if isequal(zef.zeffiro_restart, 0), addpath([zef.program_path filesep '/external/spm12/']); end
- warning on;
+if isequal(zef.zeffiro_restart, 0), addpath ( fullfile ( zef.program_path, 'external', 'SDPT3/' ) ) ; end
+if isequal(zef.zeffiro_restart, 0), addpath ( fullfile ( zef.program_path, 'external', 'SeDuMi/' ) ) ; end
+if isequal(zef.zeffiro_restart, 0), addpath ( fullfile ( zef.program_path, 'external', 'CVX/' ) ) ; end
+
+if isequal(zef.zeffiro_restart, 0)
+
+    try
+
+        evalc('cvx_startup');
+
+    catch err
+
+        warning_title = "External CVX Plugin" ;
+
+        warning_message = warning_message_fn ( "CVX", "cvx_startup" ) ;
+
+        if zef.start_mode == "display"
+
+            warning_fig = warndlg ( warning_message, warning_title ) ;
+
+            uiwait ( warning_fig ) ;
+
+        else
+
+            warning ( warning_title + ": " + warning_message ) ;
+
+        end % if
+
+    end % try
+
+end % if
+
+if isequal(zef.zeffiro_restart, 0), addpath ( fullfile( zef.program_path, 'external', 'fieldtrip/') ) ; end
+if isequal(zef.zeffiro_restart, 0)
+
+    try
+
+        evalc('ft_defaults');
+
+    catch err
+
+        warning_title = "External FieldTrip Plugin" ;
+
+        warning_message = warning_message_fn ( "FieldTrip", "ft_defaults" ) ;
+
+        if zef.start_mode == "display"
+
+            warning_fig = warndlg ( warning_message, warning_title ) ;
+
+            uiwait ( warning_fig ) ;
+
+        else
+
+            warning ( warning_title + ": " + warning_message ) ;
+
+        end % if
+
+    end % try
+
+end % if
+
+if isequal(zef.zeffiro_restart, 0), addpath ( fullfile ( zef.program_path, 'external', 'spm12/' ) ) ; end
+
+%% Helper functions.
+
+function warning_message = warning_message_fn(plugin_name, plugin_function_name)
+
+    arguments
+
+        plugin_name (1,1) string
+
+        plugin_function_name (1,1) string
+
+    end
+
+        warning_message = "The external " ...
+            + plugin_name ...
+            + " plugin function " ...
+            + plugin_function_name ...
+            + " could not be found. To use the ES Workbench plugin, please install " ...
+            + plugin_name ...
+            + " along with Zeffiro Interface by running" ...
+            + newline ...
+            + newline ...
+            + "  git submodule update --init --recursive" ...
+            + newline ...
+            + newline ...
+            + "if you downloaded the project with git clone, or install the project again with zeffiro_downloader." ;
+
+end % function


### PR DESCRIPTION
This is a squashed set of commits. See the individual commit messages below for what was changed. Closes #235.

-----------------------------------------------------------

zeffiro_interface: change position of zef.start_mode initialization

- The field is now initialized before zef_start_config is called, so that it might be used within it.

- Also ran the MATLAB Smart Indentation tool on the file.

zef_start_config: add error handling to evalc calls

- Now warnings are issued, if the external optimization plugins are not found after their addition to Matlab path has been attempted.

- If Zeffiro was started with a GUI, this warning is given as a blocking error modal window. If the Zeffiro GUI was not initialized, this is a simple non-blocking warning.

zef_start_config: add a warning message function

- The warning messages are now generated with the function warning_message_fn.

- This removes some code repetition.