### PR TITLE
.gitattributes: remove eol=lf from text file settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,13 +12,13 @@
 
 # Declare text files, whose line endings will be normalized.
 
-*.txt   text eol=lf
-*.asc   text eol=lf
-*.md    text eol=lf
-*.zef   text eol=lf
-*.m     text eol=lf
-*.sh    text eol=lf
-README  text eol=lf
+*.txt   text
+*.asc   text
+*.md    text
+*.zef   text
+*.m     text
+*.sh    text
+README  text
 
 # Then declare binary files to indicate which files should absolutely not be
 # touched, even if a user wants to.


### PR DESCRIPTION
- Now `CRLF` should be normalized to `LF`, when text files are committed on Windows machines.

- The user can of course control this, if they set `core.autocrlf` or `core.eol` Git settings on their local machine.

- Closes #240.